### PR TITLE
Suppression de URL obligatoire dans la configuration cas

### DIFF
--- a/PluginAuthCas.class.php
+++ b/PluginAuthCas.class.php
@@ -196,7 +196,7 @@ class PluginAuthCas extends PluginAuthLdap {
                         'type' => 'text',
                         'title' => get_string (self::CAS_BASEURI, 'auth.cas'),
                         'rules' => array(
-                            'required' => true,
+                            'required' => false,
                         ),
                         'defaultvalue' => self::$default_config[self::CAS_BASEURI],
                         'help' => true,

--- a/lib.php
+++ b/lib.php
@@ -68,7 +68,6 @@ class AuthCas extends AuthLdap {
 		$this->ready = parent::init($id);
 		// Check that required fields are set
 		if (empty($this->config['cas_hostname']) ||
-		empty($this->config['cas_baseuri']) ||
 		empty($this->config['cas_port']) ||
 		empty($this->config['cas_language'])
 		) {


### PR DESCRIPTION
Je me suis permis de faire une modification qui rend optionnel le paramètre URI dans la configuration du cas  parce que dans notre cas ( à l'université d'Avignon) nous n'en avons pas besoin.
