### PR TITLE
Make usernames case-insensitive

### DIFF
--- a/CAS/CAS.php
+++ b/CAS/CAS.php
@@ -475,7 +475,7 @@ class phpCAS {
 
         $PHPCAS_DEBUG['filename'] = $filename;
 
-        phpCAS :: trace ('START phpCAS-' . PHPCAS_VERSION . ' ******************');
+        phpCAS :: trace ('['. date("Y-m-d H:i:s", time()) . '] START phpCAS-' . PHPCAS_VERSION . ' ******************');
     }
 
     /** @} */

--- a/lib.php
+++ b/lib.php
@@ -129,7 +129,7 @@ class AuthCas extends AuthLdap {
 		 * this call will die with phpCAS fatal error , so no way to break in ;-)
 		 * and we do not call connectCAS() either ! this should have been done already in auth/cas/index.php
 		 */
-		if (strtolower(phpCAS::getUser()) != $username) {
+		if (strtolower(phpCAS::getUser()) != strtolower($username)) {
 			//pp_error_log("raté ","test getuser");
 			return false;
 		}


### PR DESCRIPTION
We had an issue at our institution where this plugin would not authenticate correctly for us. Our LDAP server has upper and lower case letters in the usernames and our CAS server was returning those values. When I modified the CAS server to only return lower-case letters the plugin still would not log our users in. I'm not sure why this is, but when I modified this plugin to use strtolower on both sides of the equation in an 'if' statement inside lib.php (line 132) it solved the problem. Perhaps this affects others negatively, and if so, please do not merge it in. I also added a time stamp to the phpCAS trace debugging as I found that to be somewhat helpful. Thank you for an excellent plugin.

-Jonathan Babbitt
