### PR TITLE
Updates for compatibility with Mahara 1.8

### DIFF
--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@
 defined ('INTERNAL') || die();
 
 $config = new StdClass;
-$config->version = 2008040200;
-$config->release = '1.0.0';
+$config->version = 2013100300;
+$config->release = '1.1.0';
 $config->requires_config = 1;
 $config->requires_parent = 0;


### PR DESCRIPTION
- Adding cron job
- Bumping version number so that cron will be populated by update
- Now that LDAP plugin contains a fieldset, we can't put it inside a fieldset because Mahara doesn't supported nested fieldsets
